### PR TITLE
fix: preserve non-UTF-8 bytes by uploading binary files as blobs

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1,5 +1,6 @@
 import type * as github from "@actions/github";
 import type { Octokit } from "@octokit/rest";
+import { Buffer } from "node:buffer";
 import { readFile, stat } from "node:fs/promises";
 import path from "node:path";
 
@@ -168,10 +169,10 @@ const getTreeSHA = async (
   }
   const tree: File[] = [];
   for (const filePath of opts.files || []) {
-    tree.push(await createTreeFile(opts, filePath));
+    tree.push(await createTreeFile(octokit, opts, filePath));
   }
   for (const filePath of opts.deletedFiles || []) {
-    tree.push(await createDeletedTreeFile(opts, filePath));
+    tree.push(await createDeletedTreeFile(octokit, opts, filePath));
   }
   for (const sub of opts.submodules || []) {
     tree.push({
@@ -228,10 +229,13 @@ const getFileType = (mode: FileMode): FileType => {
 };
 
 const createTreeFile = async (
+  octokit: GitHub,
   opts: Options,
   filePath: string,
 ): Promise<File> => {
   const file = await getFileContentAndMode(
+    octokit,
+    opts,
     path.join(opts.rootDir || "", filePath),
     opts.deleteIfNotExist || false,
   );
@@ -245,12 +249,16 @@ const createTreeFile = async (
 };
 
 const createDeletedTreeFile = async (
+  octokit: GitHub,
   opts: Options,
   filePath: string,
 ): Promise<File> => {
   const file = await getFileContentAndMode(
+    octokit,
+    opts,
     path.join(opts.rootDir || "", filePath),
     opts.deleteIfNotExist || false,
+    true,
   );
   return {
     path: filePath,
@@ -454,10 +462,55 @@ const getSubmoduleCommitSHA = async (
   return resolveGitHEAD(gitDir);
 };
 
+/**
+ * @internal Exported for tests.
+ *
+ * Return the buffer as a UTF-8 string iff the bytes are losslessly
+ * representable as UTF-8. `readFile(path, "utf8")` silently replaces invalid
+ * bytes with U+FFFD, so roundtripping through `toString("utf8")` and comparing
+ * bytes is the reliable way to detect lossy decodes.
+ */
+export const tryInlineUtf8 = (buf: Buffer): string | undefined => {
+  const s = buf.toString("utf8");
+  if (Buffer.byteLength(s, "utf8") !== buf.length) return undefined;
+  if (!Buffer.from(s, "utf8").equals(buf)) return undefined;
+  return s;
+};
+
+const createBlobFromBuffer = async (
+  octokit: GitHub,
+  owner: string,
+  repo: string,
+  buf: Buffer,
+): Promise<string> => {
+  const resp = await octokit.rest.git.createBlob({
+    owner,
+    repo,
+    content: buf.toString("base64"),
+    encoding: "base64",
+  });
+  return resp.data.sha;
+};
+
 const getFileContentAndMode = async (
+  octokit: GitHub,
+  opts: Options,
   filePath: string,
   deleteIfNotExist: boolean,
+  skipContent = false,
 ): Promise<File> => {
+  const readRegularFile = async (mode: FileMode): Promise<File> => {
+    if (skipContent) {
+      return { path: filePath, mode, type: getFileType(mode) };
+    }
+    const buf = await readFile(filePath);
+    const inline = tryInlineUtf8(buf);
+    if (inline !== undefined) {
+      return { path: filePath, content: inline, mode, type: getFileType(mode) };
+    }
+    const sha = await createBlobFromBuffer(octokit, opts.owner, opts.repo, buf);
+    return { path: filePath, sha, mode, type: getFileType(mode) };
+  };
   if (!deleteIfNotExist) {
     const stats = await stat(filePath);
     if (stats.isDirectory()) {
@@ -476,13 +529,7 @@ const getFileContentAndMode = async (
         type: "tree",
       };
     }
-    const mode = getFileMode(stats.mode);
-    return {
-      path: filePath,
-      content: await readFile(filePath, "utf8"),
-      mode: mode,
-      type: getFileType(mode),
-    };
+    return readRegularFile(getFileMode(stats.mode));
   }
   try {
     const stats = await stat(filePath);
@@ -502,14 +549,7 @@ const getFileContentAndMode = async (
         type: "tree",
       };
     }
-    const content = await readFile(filePath, "utf8");
-    const mode = getFileMode(stats.mode);
-    return {
-      path: filePath,
-      content,
-      mode: mode,
-      type: getFileType(mode),
-    };
+    return await readRegularFile(getFileMode(stats.mode));
   } catch (error: unknown) {
     if (typeof error !== "object" || error === undefined) {
       throw error;

--- a/main_test.ts
+++ b/main_test.ts
@@ -1,6 +1,44 @@
-// import { assertEquals } from "@std/assert";
-// import { add } from "./main.ts";
-//
-// Deno.test(function addTest() {
-//   assertEquals(add(2, 3), 5);
-// });
+import { assertEquals } from "@std/assert";
+import { Buffer } from "node:buffer";
+import { tryInlineUtf8 } from "./main.ts";
+
+Deno.test("tryInlineUtf8: ASCII", () => {
+  const buf = Buffer.from("hello world", "utf8");
+  assertEquals(tryInlineUtf8(buf), "hello world");
+});
+
+Deno.test("tryInlineUtf8: multi-byte UTF-8 (Japanese + emoji)", () => {
+  const original = "こんにちは 🌸";
+  const buf = Buffer.from(original, "utf8");
+  assertEquals(tryInlineUtf8(buf), original);
+});
+
+Deno.test("tryInlineUtf8: UTF-8 BOM is preserved byte-for-byte", () => {
+  const buf = Buffer.from([0xef, 0xbb, 0xbf, 0x61]); // BOM + "a"
+  const s = tryInlineUtf8(buf);
+  assertEquals(typeof s, "string");
+  assertEquals(Buffer.from(s as string, "utf8").equals(buf), true);
+});
+
+Deno.test("tryInlineUtf8: empty buffer", () => {
+  assertEquals(tryInlineUtf8(Buffer.alloc(0)), "");
+});
+
+Deno.test("tryInlineUtf8: invalid UTF-8 bytes return undefined", () => {
+  // 0xFF is never a valid UTF-8 start/continuation byte.
+  const buf = Buffer.from([0xff, 0xfe, 0x00, 0x01]);
+  assertEquals(tryInlineUtf8(buf), undefined);
+});
+
+Deno.test("tryInlineUtf8: UTF-8 encoded surrogate returns undefined", () => {
+  // ED A0 80 is the UTF-8 encoding of U+D800, which is a reserved surrogate
+  // and not valid in well-formed UTF-8.
+  const buf = Buffer.from([0xed, 0xa0, 0x80]);
+  assertEquals(tryInlineUtf8(buf), undefined);
+});
+
+Deno.test("tryInlineUtf8: truncated multi-byte sequence returns undefined", () => {
+  // First byte of a 3-byte sequence, but the continuation bytes are missing.
+  const buf = Buffer.from([0xe3, 0x81]);
+  assertEquals(tryInlineUtf8(buf), undefined);
+});


### PR DESCRIPTION
## Why

`getFileContentAndMode` in `main.ts` was reading files with `await readFile(filePath, "utf8")` and passing the resulting string as the inline `content` of a GitHub `createTree` entry. Node's UTF-8 decoder silently replaces any invalid byte sequence with U+FFFD (the replacement character, `0xEF 0xBF 0xBD` in UTF-8), so any file containing non-UTF-8 bytes — binaries, Shift_JIS text, images, PDFs, etc. — was being corrupted before it ever reached GitHub.

The blob that ended up on GitHub therefore disagreed with the original bytes on disk. In downstream tooling like `csm-actions/securefix-action` this produced a visible symptom: the next CI run would regenerate the file with the original bytes, git would see a diff, `commit-ts` would write the same corrupted blob again, the resulting tree SHA would equal the parent's tree SHA, and the action would keep producing empty commits in a loop.

## What changed

### Hybrid inline / blob upload in `getFileContentAndMode`

- `Buffer` is now imported from `node:buffer` and the file is read as a raw `Buffer` (`await readFile(filePath)`), not a UTF-8 string.
- Two new helpers:
  - `tryInlineUtf8(buf)` — returns the buffer decoded as a UTF-8 string **only if** the decode is lossless. It does this by roundtripping: it checks `Buffer.byteLength(s, "utf8") === buf.length` and `Buffer.from(s, "utf8").equals(buf)`. Any invalid byte makes `toString("utf8")` produce a U+FFFD, which breaks the byte-length or byte-equality check and causes the helper to return `undefined`. Exported with `@internal` for tests.
  - `createBlobFromBuffer(octokit, owner, repo, buf)` — base64-encodes the buffer and POSTs it to `POST /repos/{owner}/{repo}/git/blobs` with `encoding: "base64"`, returning the blob SHA.
- The regular-file branch in `getFileContentAndMode` now calls a local `readRegularFile(mode)` which:
  1. Reads the file as a Buffer.
  2. Tries `tryInlineUtf8`. If the file is losslessly UTF-8 (the common case — all source code, JSON, YAML, Markdown, etc.), it is sent inline as before with `content: <string>`. Existing users of `commit-ts` see no extra API calls.
  3. Otherwise, it calls `createBlobFromBuffer` and the tree entry is written with `sha: <blob sha>` instead of `content`. GitHub's `createTree` accepts a mix of `content` and `sha` entries, so the rest of the tree is unaffected.
- No size threshold is used — the hybrid decision is driven purely by "is this UTF-8 lossless?" as proposed in `BUG-utf8-binary-loss.md`. Simpler, and avoids getting it wrong for a 50-byte binary that happens to be below any threshold.

### Signature threading

To call `createBlob`, `getFileContentAndMode` needs access to `octokit`, `opts.owner`, and `opts.repo`. These are threaded through:

- `getFileContentAndMode(octokit, opts, filePath, deleteIfNotExist, skipContent=false)`
- `createTreeFile(octokit, opts, filePath)`
- `createDeletedTreeFile(octokit, opts, filePath)`
- `getTreeSHA` already has both `octokit` and `opts` and just forwards them at the two call sites.

All of these are module-private; **the exported surface (`createCommit`, `Options`, `Result`, `Logger`, `GitHub`) is unchanged and fully backwards compatible.**

### `skipContent` for the deletion path

`createDeletedTreeFile` only needs the file's mode — it returns `{ path, mode, type, sha: null }` and discards everything else. Previously it still paid the cost of `readFile` on the file's content. With the hybrid scheme that would also waste a `createBlob` call for any binary file being deleted. To avoid that, `getFileContentAndMode` now takes a `skipContent` flag; when it's `true`, the regular-file path returns just the mode without reading content. `createDeletedTreeFile` passes `skipContent: true`.

### Unchanged behavior

- Submodule detection (`.git` file → resolve HEAD), directory → `040000`, and submodule → `160000` branches are untouched.
- ENOENT handling for `deleteIfNotExist: true` still returns `{ sha: null, mode: "100644", ... }`.
- `.git`, `HEAD`, and `packed-refs` are still read with `"utf8"` — those files are ASCII-only, and using a UTF-8 decode there is fine.
- The iteration in `getTreeSHA` is still sequential (`for … await`); parallelizing via `Promise.all` is out of scope for this PR.

## Tests

`main_test.ts` previously contained only commented-out skeleton code. It now has seven unit tests targeting `tryInlineUtf8`:

- ASCII (`"hello world"`)
- Multi-byte UTF-8 (Japanese + emoji)
- UTF-8 BOM preserved byte-for-byte
- Empty buffer
- Invalid UTF-8 bytes (`0xFF …`) → `undefined`
- UTF-8-encoded surrogate (`ED A0 80`) → `undefined`
- Truncated multi-byte sequence (`E3 81`) → `undefined`

Higher-level hybrid behavior (verifying that `createBlob` is called for binary fixtures) requires a mocked octokit and is out of scope here; it would need a small mocking scaffold that doesn't yet exist in the repo.

## Verification

```bash
deno check main.ts main_test.ts
deno lint main.ts main_test.ts
deno fmt --check main.ts main_test.ts
deno test --allow-read main_test.ts
```

## References

- GitHub REST — [Create a blob](https://docs.github.com/en/rest/git/blobs#create-a-blob): `encoding: "base64"` is accepted and supports up to ~100MB.
- GitHub REST — [Create a tree](https://docs.github.com/en/rest/git/trees#create-a-tree): tree entries may specify either `content` or `sha`, and both kinds can be mixed in a single call.
- Node.js — [`Buffer`](https://nodejs.org/api/buffer.html) used to detect lossy UTF-8 decodes by byte-level roundtrip.
