### PR TITLE
refactor: drop dead path assignment from getFileContentAndMode

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -498,18 +498,20 @@ const getFileContentAndMode = async (
   filePath: string,
   deleteIfNotExist: boolean,
   skipContent = false,
-): Promise<File> => {
-  const readRegularFile = async (mode: FileMode): Promise<File> => {
+): Promise<Omit<File, "path">> => {
+  const readRegularFile = async (
+    mode: FileMode,
+  ): Promise<Omit<File, "path">> => {
     if (skipContent) {
-      return { path: filePath, mode, type: getFileType(mode) };
+      return { mode, type: getFileType(mode) };
     }
     const buf = await readFile(filePath);
     const inline = tryInlineUtf8(buf);
     if (inline !== undefined) {
-      return { path: filePath, content: inline, mode, type: getFileType(mode) };
+      return { content: inline, mode, type: getFileType(mode) };
     }
     const sha = await createBlobFromBuffer(octokit, opts.owner, opts.repo, buf);
-    return { path: filePath, sha, mode, type: getFileType(mode) };
+    return { sha, mode, type: getFileType(mode) };
   };
   if (!deleteIfNotExist) {
     const stats = await stat(filePath);
@@ -517,14 +519,12 @@ const getFileContentAndMode = async (
       const commitSHA = await getSubmoduleCommitSHA(filePath);
       if (commitSHA !== undefined) {
         return {
-          path: filePath,
           mode: "160000",
           type: "commit",
           sha: commitSHA,
         };
       }
       return {
-        path: filePath,
         mode: "040000",
         type: "tree",
       };
@@ -537,14 +537,12 @@ const getFileContentAndMode = async (
       const commitSHA = await getSubmoduleCommitSHA(filePath);
       if (commitSHA !== undefined) {
         return {
-          path: filePath,
           mode: "160000",
           type: "commit",
           sha: commitSHA,
         };
       }
       return {
-        path: filePath,
         mode: "040000",
         type: "tree",
       };
@@ -562,7 +560,6 @@ const getFileContentAndMode = async (
     const mode = "100644";
     return {
       sha: null,
-      path: filePath,
       mode: mode,
       type: getFileType(mode),
     };


### PR DESCRIPTION
## Why

Follow-up cleanup noted during review of #275 (merged as `0079c0d`).

`getFileContentAndMode` in `main.ts` returned a `File` whose `path` field was set to the **joined** path (`path.join(opts.rootDir || "", filePath)`) in every return branch — regular file, directory, submodule, and the ENOENT-deletion branch. But both callers always override that field with the un-joined `filePath` argument when they construct the final tree entry:

- `createTreeFile` (main.ts:242) writes `path: filePath` itself and only reads `sha`, `mode`, and `content` from the inner result.
- `createDeletedTreeFile` (main.ts:263) writes `path: filePath` itself and only reads `mode`.

So the inner `path` assignment was dead in every branch. It was harmless, but misleading — a reader might assume some branch relies on the joined path. This PR removes the dead assignments and narrows the return type so the compiler enforces the invariant.

This predates #275; PR #275 just inherited the pattern.

## What changed

All changes are inside `main.ts`; no caller changes are needed.

- **Return type narrowed** from `Promise<File>` to `Promise<Omit<File, "path">>` on:
  - `getFileContentAndMode` (outer)
  - `readRegularFile` (inner closure)
- **Dropped `path: filePath`** from all seven return branches:
  - Three inside `readRegularFile` (`skipContent`, inline-UTF-8, blob fallback)
  - Two inside the `!deleteIfNotExist` arm (submodule, directory)
  - Two inside the `deleteIfNotExist` try block (submodule, directory)
  - One in the ENOENT catch branch
- The `File` type itself is unchanged; `path` remains a required field on tree entries passed to `createTree`. Callers already supply it.

No behavioral change. No change to the public surface (`createCommit`, `Options`, `Result`, `Logger`, `GitHub`).

## Verification

```bash
deno check main.ts main_test.ts      # pass
deno lint main.ts main_test.ts       # pass
deno fmt --check main.ts main_test.ts # pass
deno test --allow-read main_test.ts   # 7/7 pass
```

All seven existing `tryInlineUtf8` tests continue to pass. No new tests are warranted since this is a pure type-narrowing cleanup.