### PR TITLE
refactor: split tree entry into File and DeletedFile types

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -99,10 +99,17 @@ type FileMode = "100644" | "100755" | "040000" | "160000" | "120000";
 type File = {
   path: string;
   content?: string;
-  sha?: string | null;
+  sha?: string;
   mode: FileMode;
-  type?: FileType;
+  type: FileType;
 };
+
+type DeletedFile = {
+  path: string;
+  sha: null;
+};
+
+type TreeEntry = File | DeletedFile;
 
 type DefaultBranchResponse = {
   repository: {
@@ -167,12 +174,12 @@ const getTreeSHA = async (
   if (opts.empty) {
     return baseBranch.target.tree.oid;
   }
-  const tree: File[] = [];
+  const tree: TreeEntry[] = [];
   for (const filePath of opts.files || []) {
     tree.push(await createTreeFile(octokit, opts, filePath));
   }
   for (const filePath of opts.deletedFiles || []) {
-    tree.push(await createDeletedTreeFile(octokit, opts, filePath));
+    tree.push(createDeletedTreeFile(filePath));
   }
   for (const sub of opts.submodules || []) {
     tree.push({
@@ -232,41 +239,23 @@ const createTreeFile = async (
   octokit: GitHub,
   opts: Options,
   filePath: string,
-): Promise<File> => {
+): Promise<TreeEntry> => {
   const file = await getFileContentAndMode(
     octokit,
     opts,
     path.join(opts.rootDir || "", filePath),
     opts.deleteIfNotExist || false,
   );
-  return {
-    path: filePath,
-    sha: file.sha,
-    mode: file.mode,
-    type: getFileType(file.mode),
-    content: file.content,
-  };
+  if (file.sha === null) {
+    return { path: filePath, sha: null };
+  }
+  return { path: filePath, ...file };
 };
 
-const createDeletedTreeFile = async (
-  octokit: GitHub,
-  opts: Options,
-  filePath: string,
-): Promise<File> => {
-  const file = await getFileContentAndMode(
-    octokit,
-    opts,
-    path.join(opts.rootDir || "", filePath),
-    opts.deleteIfNotExist || false,
-    true,
-  );
-  return {
-    path: filePath,
-    mode: file.mode,
-    type: getFileType(file.mode),
-    sha: null,
-  };
-};
+const createDeletedTreeFile = (filePath: string): DeletedFile => ({
+  path: filePath,
+  sha: null,
+});
 
 const getBaseBranch = async (
   octokit: GitHub,
@@ -497,14 +486,10 @@ const getFileContentAndMode = async (
   opts: Options,
   filePath: string,
   deleteIfNotExist: boolean,
-  skipContent = false,
-): Promise<Omit<File, "path">> => {
+): Promise<Omit<File, "path"> | { sha: null }> => {
   const readRegularFile = async (
     mode: FileMode,
   ): Promise<Omit<File, "path">> => {
-    if (skipContent) {
-      return { mode, type: getFileType(mode) };
-    }
     const buf = await readFile(filePath);
     const inline = tryInlineUtf8(buf);
     if (inline !== undefined) {
@@ -557,12 +542,7 @@ const getFileContentAndMode = async (
       throw error;
     }
     // If the file does not exist, remove the file
-    const mode = "100644";
-    return {
-      sha: null,
-      mode: mode,
-      type: getFileType(mode),
-    };
+    return { sha: null };
   }
 };
 


### PR DESCRIPTION
## Why

Follow-up cleanup from the review of #275. The review flagged that `createDeletedTreeFile` computed `type: getFileType(file.mode)` even though GitHub's `createTree` API ignores both `type` and `mode` for entries with `sha: null`. Once `type` and `mode` are dead for the deletion path, the entire `getFileContentAndMode` call in that function becomes unnecessary — along with the `skipContent` parameter that #275 added solely to serve this caller.

A first draft kept a single `File` type and relaxed `mode` to optional to fit both shapes, but that loses a real invariant: in every non-deletion code path, `mode` and `type` are always set. Relaxing them on the shared type pushed `undefined`-that-can-never-occur onto creation-site callers. Splitting the type cleanly encodes the API's actual discrimination — create/update vs. delete — and lets both `mode` and `type` stay required on the creation side.

Confirmed against octokit's OpenAPI-generated types for `git/create-tree`: `path`, `mode`, `type`, `sha`, and `content` are all optional at the request-body level, so `{ path, sha: null }` is a valid deletion entry.

## What changed

All changes are in `main.ts`; no public API changes, no test changes.

### Type split

```ts
type File = {
  path: string;
  content?: string;
  sha?: string;        // was `sha?: string | null`
  mode: FileMode;      // required (was required, now still required)
  type: FileType;      // required (was optional)
};

type DeletedFile = {
  path: string;
  sha: null;
};

type TreeEntry = File | DeletedFile;
```

Tree assembly in `getTreeSHA` uses `const tree: TreeEntry[] = [];`.

### Caller simplifications

- `createTreeFile` now returns `Promise<TreeEntry>`. When `getFileContentAndMode` signals ENOENT via `{ sha: null }`, the caller emits a `DeletedFile`; otherwise it spreads the inner shape into a full `File`. The explicit `type: getFileType(file.mode)` recomputation goes away — `file.type` already has it.
- `createDeletedTreeFile` collapses to a synchronous one-liner returning `DeletedFile`. It no longer takes `octokit` or `opts`, no longer awaits anything, and no longer calls `getFileContentAndMode` / `stat` / `readFile`.
- `getFileContentAndMode` return type becomes `Promise<Omit<File, "path"> | { sha: null }>`. The `skipContent` parameter is gone. The ENOENT branch collapses to `return { sha: null };` (the dead `mode: "100644"` / `type: getFileType(mode)` are dropped).

### Incidental behavior change

Paths in `opts.deletedFiles` that no longer exist on disk now work regardless of `opts.deleteIfNotExist`. Previously, with `deleteIfNotExist: false`, `createDeletedTreeFile` would call `getFileContentAndMode` which would call `stat()` and throw `ENOENT`. `deleteIfNotExist` remains meaningful for `opts.files` (where a missing file should be converted to a deletion).

## Verification

```bash
deno check main.ts main_test.ts      # pass
deno lint main.ts main_test.ts       # pass
deno fmt --check main.ts main_test.ts # pass
deno test --allow-read main_test.ts   # 7/7 pass
```