### PR TITLE
fix: include mode in deletion tree entries

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -107,6 +107,7 @@ type File = {
 type DeletedFile = {
   path: string;
   sha: null;
+  mode: FileMode;
 };
 
 type TreeEntry = File | DeletedFile;
@@ -247,7 +248,8 @@ const createTreeFile = async (
     opts.deleteIfNotExist || false,
   );
   if (file.sha === null) {
-    return { path: filePath, sha: null };
+    // mode is required by the Create a tree API even for deletions (sha: null).
+    return { path: filePath, sha: null, mode: "100644" };
   }
   return { path: filePath, ...file };
 };
@@ -255,6 +257,7 @@ const createTreeFile = async (
 const createDeletedTreeFile = (filePath: string): DeletedFile => ({
   path: filePath,
   sha: null,
+  mode: "100644",
 });
 
 const getBaseBranch = async (


### PR DESCRIPTION
## Summary

GitHub's [Create a tree API](https://docs.github.com/en/rest/git/trees#create-a-tree) requires a `mode` on every entry — including deletion entries (`sha: null`). Until now, `commit-ts` produced deletion entries without a `mode` field, so the API rejected such requests with:

> Must supply a valid tree.mode

This made the `deletedFiles` / `deleteIfNotExist` paths unusable in practice.

- https://github.com/szksh-lab/securefix-demo-client/pull/68#issuecomment-4317952764

## Changes (`main.ts`)

- `DeletedFile` type: add a required `mode: FileMode` field so deletion entries carry a mode through the type system.
- `createTreeFile`: when the underlying file resolved to `sha: null` (i.e. a deletion), emit `mode: "100644"` instead of dropping the field. Inline comment explains that the API requires it even for deletions.
- `createDeletedTreeFile`: same treatment — explicit deletions now ship with `mode: "100644"`.

`"100644"` (regular non-executable file) is used as the mode for all deletions. The mode value on a deletion entry is structurally required by the API but does not affect the resulting tree, since the entry is removing the path rather than describing its contents.

## Affected paths

- `opts.deletedFiles` — explicit deletions requested by the caller.
- `opts.deleteIfNotExist: true` — deletions inferred from a file being missing locally.

Both flows now produce API-valid tree entries.

## Backward compatibility

No public API change. `Options`, `createCommit`, and the exported types are untouched. Behaviour for non-deletion entries is unchanged.